### PR TITLE
feat(attributebar): Add stacked layout option and refactor bar system

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@
 ### Known Issues
 - The Action Bar ultimate button scaling may not reset correctly after bar swaps in some scenarios.
 
+### v1.10.48
+- **Added:** New "Stacked" layout option for attribute bars - all three bars stacked vertically with health on top, stamina in middle, and magicka on bottom.
+- **Improved:** Attribute bar layout system - replaced pyramid toggle checkbox with comprehensive layout dropdown including Default, ShibUI, Pyramid, and Stacked options.
+- **Enhanced:** Mount stamina bar positioning in stacked layout - positioned to the side of regular stamina bar when mounted.
+- **Optimized:** Attribute bar sizing system to use ESO's built-in width constants (SHRUNK_WIDTH, NORMAL_WIDTH, EXPANDED_WIDTH) from ZO_UnitVisualizer_ShrinkExpandModule.
+- **Refactored:** Attribute bar module to use proper colon-style methods (AttributeBar:ApplySize(), AttributeBar:ApplyLayout()) for better OOP consistency.
+- **Updated:** SavedVars defaults - replaced `attributeBarPyramid` boolean with `attributeBarLayout` string, defaulting to "shibui".
+- **Cleaned:** Code structure with improved organization, consistent naming conventions, and removal of redundant flag variables.
+
 ### v1.9.48
 - **Added:** Chat Window Module.
 - **Fixed:** `PlayerProgressBar` Now shows below original position to avoid overlapping when always visible.

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -7,3 +7,46 @@
 | **Usuzumi (薄墨)**	| ` #D4D4D4`	| Light grey with a whisper of cool tone—clean and neutral	|
 | **Tōryoku (淡緑)**	| ` #C9D8C5`	| Muted sage—adds depth without heaviness	|
 | **Shirocha (白茶)**	| ` #EDE6DB`	| Off-white with a warm beige tint—great for background balance	|
+
+# Analysis Summary: ZO_PlayerAttribute Control Structure
+Health Bar (ZO_PlayerAttributeHealth)
+StatusBars:
+
+BarLeft - inherits ZO_PlayerAttributeStatusBar, barAlignment="REVERSE"
+Contains: Gloss child (also REVERSE)
+BarRight - inherits ZO_PlayerAttributeStatusBar, normal alignment
+Contains: Gloss child
+Decorative Elements:
+
+BgContainer with children: BgLeft (arrow), BgRight (arrow), BgCenter
+FrameLeft (arrow), FrameRight (arrow), FrameCenter
+Warner control with Left (arrow), Right (arrow), Center
+ResourceNumbers label
+Magicka Bar (ZO_PlayerAttributeMagicka)
+StatusBars:
+
+Bar - inherits ZO_PlayerAttributeStatusBar, barAlignment="REVERSE"
+Contains: Gloss child (also REVERSE)
+Decorative Elements:
+
+BgContainer with children: BgLeft (arrow), BgRight (no arrow), BgCenter
+FrameLeft (arrow), FrameRight (no arrow), FrameCenter
+Warner control with Left (arrow), Right (no arrow), Center
+ResourceNumbers label
+Stamina Bar (ZO_PlayerAttributeStamina)
+StatusBars:
+
+Bar - inherits ZO_PlayerAttributeStatusBar, normal alignment (no REVERSE)
+Contains: Gloss child
+Decorative Elements:
+
+BgContainer with children: BgLeft (no arrow), BgRight (arrow), BgCenter
+FrameLeft (no arrow), FrameRight (arrow), FrameCenter
+Warner control with Left (no arrow), Right (arrow), Center
+ResourceNumbers label
+Key Differences:
+Health has TWO StatusBars (BarLeft + BarRight) that meet in center for bidirectional depletion
+Magicka has ONE StatusBar with REVERSE alignment (depletes right-to-left)
+Stamina has ONE StatusBar with normal alignment (depletes left-to-right)
+Arrow decorations are on different sides: Magicka (left), Health (both), Stamina (right)
+All StatusBars inherit from ZO_PlayerAttributeStatusBar template which likely defines the bar texture with arrow shapes built-in

--- a/ShibUI/ShibUI.lua
+++ b/ShibUI/ShibUI.lua
@@ -12,7 +12,7 @@ SUI = SUI or {}
 SUI.name        = "ShibUI"
 SUI.menuName    = "ShibUI Settings"
 SUI.displayName = "Shibui User Interface"
-SUI.version     = "1.9.48" 
+SUI.version     = "1.10.48" 
 SUI.author      = "Shownie & Ai"
 SUI.description = "ShibUI is a modern and minimalistic UI."
 

--- a/ShibUI/ShibUI.txt
+++ b/ShibUI/ShibUI.txt
@@ -1,7 +1,7 @@
 ## Title: ShibUI
 ## Description: ShibUI is a minimalistic ESO addon that cleans up and modernizes the user interface.
-## Version: 1.9.48
-## AddOnVersion: 1948
+## Version: 1.10.48
+## AddOnVersion: 11048
 ## APIVersion: 101048 101049
 ## Author: Shownie & Ai
 ## OptionalDependsOn: LibAddonMenu-2.0

--- a/ShibUI/hud/attributebar.lua
+++ b/ShibUI/hud/attributebar.lua
@@ -1,13 +1,14 @@
 --------------------------------------------------
 -- ShibUI Attribute Bar Module
 --------------------------------------------------
+
 local SUI = SUI
 local sv
 
 SUI.AttributeBar = SUI.AttributeBar or {}
 local AttributeBar = SUI.AttributeBar
 
-local Log = function(...) SUI.Debug:Log("AttributeBar", ...) end
+local Log = function(...) SUI.Debug:Log("Attribute Bar", ...) end
 
 ---------------------------------------------------
 -- Texture Redirection for Attribute Bar
@@ -39,103 +40,79 @@ local function DefaultTextures()
 end
 
 ---------------------------------------------------
--- Attribute Bar size and layout control
+-- Attribute Bar Size and Layout Control
 ---------------------------------------------------
-local shrunkWidth = 141 -- ESO default values
-local normalWidth = 237 -- ESO default values
-local expandedWidth = 323 -- ESO default values
+
+-- ESO default width values from ZO_UnitVisualizer_ShrinkExpandModule
+local SHRUNK_WIDTH = 141
+local NORMAL_WIDTH = 237
+local EXPANDED_WIDTH = 323
 
 local pBar = ZO_PlayerAttribute
 local hpBar = ZO_PlayerAttributeHealth
 local mpBar = ZO_PlayerAttributeMagicka
 local spBar = ZO_PlayerAttributeStamina
+local mountBar = ZO_PlayerAttributeMountStamina
 
 local bars = { hpBar, mpBar, spBar }
+
+-- Get individual bar controls for manipulation
+local hpBarLeft = GetControl(hpBar, "BarLeft")
+local hpBarRight = GetControl(hpBar, "BarRight")
+local mpBarSingle = GetControl(mpBar, "Bar")
+local spBarSingle = GetControl(spBar, "Bar")
+local mountBarSingle = mountBar and GetControl(mountBar, "Bar")
+
+---------------------------------------------------
+-- Bar Size Control
+---------------------------------------------------
 
 local function LockBarWidth(bar, width)
     bar:SetWidth(width)
 end
 
-local function UnlockBarWidth(bar)
-    -- Do nothing; let ESO handle the width dynamically
-end
-
-local barSizeNormal = false
-local barSizeDefault = false
-local barSizeExpanded = false
-
-local function ResetBarSizeFlags()
-    barSizeNormal = false
-    barSizeDefault = false
-    barSizeExpanded = false
-end
-
-local function SetBarSizeToNormal()
-    for _, bar in ipairs(bars) do
-        LockBarWidth(bar, normalWidth)
-    end
-    if not barSizeNormal then
-        barSizeNormal = true
-    end
-end
-
-local function SetBarSizeToDefault()
-    for _, bar in ipairs(bars) do
-        -- Reset to ESO's default dynamic behavior
-        UnlockBarWidth(bar)
-    end
-    if not barSizeDefault then
-        barSizeDefault = true
-    end
-end
-
-local function SetBarSizeToExpanded()
-    for _, bar in ipairs(bars) do
-        LockBarWidth(bar, expandedWidth)
-    end
-    if not barSizeExpanded then
-        barSizeExpanded = true
-    end
-end
-
--- Event handler to keep bar width locked live
 local function OnAttributeBarRelevantUpdate()
-    if sv and sv.attributeBar then
-        if sv then
-            SUI.ApplyAttributeBarSize(sv.attributeBarSize)
-        else
-            SUI.ApplyAttributeBarSize("default")
-        end
+    if sv and sv.attributeBarSize then
+        AttributeBar:ApplySize(sv.attributeBarSize)
     end
 end
 
-function SUI.ApplyAttributeBarSize(mode)
-    ResetBarSizeFlags()
+function AttributeBar:ApplySize(mode)
     if mode == "default" then
-        -- Unregister events so bars can resize dynamically
         EVENT_MANAGER:UnregisterForEvent("ShibUI_AttributeBarLock_Stats", EVENT_STATS_UPDATED)
         EVENT_MANAGER:UnregisterForEvent("ShibUI_AttributeBarLock_Power", EVENT_POWER_UPDATE)
-        SetBarSizeToDefault()
-    elseif mode == "normal" or mode == "expanded" then
-        -- Register events to keep width locked
+        
+        for _, bar in ipairs(bars) do
+            bar:SetWidth(NORMAL_WIDTH)
+        end
+    elseif mode == "normal" then
         EVENT_MANAGER:RegisterForEvent("ShibUI_AttributeBarLock_Stats", EVENT_STATS_UPDATED, OnAttributeBarRelevantUpdate)
         EVENT_MANAGER:RegisterForEvent("ShibUI_AttributeBarLock_Power", EVENT_POWER_UPDATE, function(_, unitTag)
             if unitTag == "player" then
                 OnAttributeBarRelevantUpdate()
             end
         end)
-        if mode == "normal" then
-            SetBarSizeToNormal()
-        else
-            SetBarSizeToExpanded()
+        
+        for _, bar in ipairs(bars) do
+            LockBarWidth(bar, NORMAL_WIDTH)
         end
-    else
+    elseif mode == "expanded" then
+        EVENT_MANAGER:RegisterForEvent("ShibUI_AttributeBarLock_Stats", EVENT_STATS_UPDATED, OnAttributeBarRelevantUpdate)
+        EVENT_MANAGER:RegisterForEvent("ShibUI_AttributeBarLock_Power", EVENT_POWER_UPDATE, function(_, unitTag)
+            if unitTag == "player" then
+                OnAttributeBarRelevantUpdate()
+            end
+        end)
+        
+        for _, bar in ipairs(bars) do
+            LockBarWidth(bar, EXPANDED_WIDTH)
+        end
     end
 end
 
-local barLayoutPyramid = false
-local barLayoutShibui = false
-local barLayoutDefault = false
+---------------------------------------------------
+-- Bar Layout Control
+---------------------------------------------------
 
 local function ClearAllBarAnchors()
     for _, bar in ipairs(bars) do
@@ -143,73 +120,89 @@ local function ClearAllBarAnchors()
     end
 end
 
-local function SetLayoutPyramid()
+local function SetLayoutDefault()
     ClearAllBarAnchors()
-
-    hpBar:SetAnchor(BOTTOM, GuiRoot, BOTTOM, 0, -115)
-    mpBar:SetAnchor(BOTTOMRIGHT, GuiRoot, BOTTOM, -5, -90)
-    spBar:SetAnchor(BOTTOMLEFT, GuiRoot, BOTTOM, 5, -90)
-
-    if not barLayoutPyramid then
-        barLayoutPyramid = true
-    end
+    
+    hpBar:SetAnchor(CENTER, pBar, CENTER, 0, 0)
+    mpBar:SetAnchor(RIGHT, pBar, LEFT, 237, 0)
+    spBar:SetAnchor(LEFT, pBar, RIGHT, -237, 0)
+    
+    pBar:ClearAnchors()
+    pBar:SetAnchor(BOTTOM, GuiRoot, BOTTOM, 0, -74)
 end
 
 local function SetLayoutShibui()
     ClearAllBarAnchors()
-
+    
     hpBar:SetAnchor(BOTTOM, GuiRoot, BOTTOM, 0, -94)
     mpBar:SetAnchor(BOTTOMRIGHT, GuiRoot, BOTTOM, -200, -94)
     spBar:SetAnchor(BOTTOMLEFT, GuiRoot, BOTTOM, 200, -94)
-
-    if not barLayoutShibui then
-        barLayoutShibui = true
-    end
 end
 
-local function SetLayoutDefault()
+local function SetLayoutPyramid()
     ClearAllBarAnchors()
-
-    hpBar:SetAnchor(CENTER, pBar, CENTER, 0, 0)
-    mpBar:SetAnchor(RIGHT, pBar, LEFT, 237, 0)
-    spBar:SetAnchor(LEFT, pBar, RIGHT, -237, 0)
-
-    pBar:ClearAnchors()
-    pBar:SetAnchor(BOTTOM, GuiRoot, BOTTOM, 0, -74)
-
-    if not barLayoutDefault then
-        barLayoutDefault = true
-    end
+    
+    hpBar:SetAnchor(BOTTOM, GuiRoot, BOTTOM, 0, -115)
+    mpBar:SetAnchor(BOTTOMRIGHT, GuiRoot, BOTTOM, -5, -90)
+    spBar:SetAnchor(BOTTOMLEFT, GuiRoot, BOTTOM, 5, -90)
 end
 
-function SUI.ApplyAttributeBarLayout(layout)
-        if layout == "pyramid" then
-            SetLayoutPyramid()
-        elseif layout == "shibui" then
-            SetLayoutShibui()
-        elseif layout == "default" then
-            SetLayoutDefault()
-        else
+local function SetLayoutStacked()
+    ClearAllBarAnchors()
+    
+    -- Stack all bars vertically with health on top, centered
+    hpBar:SetAnchor(BOTTOM, GuiRoot, BOTTOM, 0, -120)
+    spBar:SetAnchor(TOP, hpBar, BOTTOM, 0, 2)
+    mpBar:SetAnchor(TOP, spBar, BOTTOM, 0, 2)
+    
+    -- Mount stamina bar positioned to the side when mounted
+    if mountBar then
+        mountBar:ClearAnchors()
+        mountBar:SetAnchor(LEFT, spBar, RIGHT, 10, 0)
+    end
+    
+    -- Set bar heights to half
+    local halfHeight = 15
+    hpBar:SetHeight(halfHeight)
+    spBar:SetHeight(halfHeight)
+    mpBar:SetHeight(halfHeight)
+    if mountBar then
+        mountBar:SetHeight(halfHeight)
+    end
+    
+    -- Set sub-bar controls heights
+    if hpBarLeft then hpBarLeft:SetHeight(halfHeight) end
+    if hpBarRight then hpBarRight:SetHeight(halfHeight) end
+    if spBarSingle then spBarSingle:SetHeight(halfHeight) end
+    if mpBarSingle then mpBarSingle:SetHeight(halfHeight) end
+    if mountBarSingle then mountBarSingle:SetHeight(halfHeight) end
+end
+
+function AttributeBar:ApplyLayout(layout)
+    if layout == "default" then
+        SetLayoutDefault()
+    elseif layout == "shibui" then
+        SetLayoutShibui()
+    elseif layout == "pyramid" then
+        SetLayoutPyramid()
+    elseif layout == "stacked" then
+        SetLayoutStacked()
     end
 end
 
 ---------------------------------------------------
--- Apply Attribute Bar Settings
+-- Initialization
 ---------------------------------------------------
 function AttributeBar:Initialize()
     sv = SUI.SavedVars.saved
-
-    BlankTextures()
-
-    SUI.ApplyAttributeBarSize(sv.attributeBarSize)
-        
-    EVENT_MANAGER:UnregisterForEvent("ShibUI_AttributeBarWidth", EVENT_STATS_UPDATED)
-    local layout = sv.attributeBarPyramid and "pyramid" or "shibui"
-    SUI.ApplyAttributeBarLayout(layout)
     
-    EVENT_MANAGER:RegisterForEvent("ShibUI_AttributeBarWidth", EVENT_STATS_UPDATED, function()
-        local layout = sv.attributeBarPyramid and "pyramid" or "shibui"
-        SUI.ApplyAttributeBarLayout(layout)
+    BlankTextures()
+    
+    self:ApplySize(sv.attributeBarSize)
+    self:ApplyLayout(sv.attributeBarLayout)
+    
+    EVENT_MANAGER:RegisterForEvent("ShibUI_AttributeBarLayout", EVENT_STATS_UPDATED, function()
+        AttributeBar:ApplyLayout(sv.attributeBarLayout)
     end)
     
     Log("Initialized")

--- a/ShibUI/settings/savedvars.lua
+++ b/ShibUI/settings/savedvars.lua
@@ -17,7 +17,7 @@ SUI.SavedVars.defaults = {
 
     -- Attribute Bar
     attributeBar = true,
-    attributeBarPyramid = false,
+    attributeBarLayout = "shibui",
     attributeBarSize = "default",
 
     -- Target Bar

--- a/ShibUI/settings/settings.lua
+++ b/ShibUI/settings/settings.lua
@@ -137,30 +137,31 @@ local function AttributeBarSettings()
     return {
         {
             type = "header",
-            name = "Attribute Bar Layout Preview",
-        },
-        {
-            type = "checkbox",
-            name = "Pyramid Layout",
-            tooltip = "Stack attribute bars in a pyramid style (Health on top of Magicka and Stamina).",
-            getFunc = function() return sv.attributeBarPyramid end,
-            setFunc = function(value)
-                sv.attributeBarPyramid = value
-                local layout = value and "pyramid" or "shibui"
-                SUI.ApplyAttributeBarLayout(layout)
-            end,
-            default = SUI.SavedVars.defaults.attributeBarPyramid,
+            name = "Attribute Bar Settings",
         },
         {
             type = "dropdown",
-            name = "Attribute Bar Width Mode",
+            name = "Bar Layout",
+            tooltip = "Choose the layout style for attribute bars:\n• Default - ESO's original centered layout\n• ShibUI - Horizontal spread layout\n• Pyramid - Health on top, Magicka and Stamina below\n• Stacked - All bars stacked vertically",
+            choices = { "Default", "ShibUI", "Pyramid", "Stacked" },
+            choicesValues = { "default", "shibui", "pyramid", "stacked" },
+            getFunc = function() return sv.attributeBarLayout end,
+            setFunc = function(layout)
+                sv.attributeBarLayout = layout
+                SUI.AttributeBar:ApplyLayout(layout)
+            end,
+            default = SUI.SavedVars.defaults.attributeBarLayout,
+        },
+        {
+            type = "dropdown",
+            name = "Bar Width",
             tooltip = "Choose Normal or Expanded for fixed width, or Default for dynamic width based on current stats.",
-            choices = { "Normal", "Default", "Expanded" },
-            choicesValues = { "normal", "default", "expanded" },
+            choices = { "Default", "Normal", "Expanded" },
+            choicesValues = { "default", "normal", "expanded" },
             getFunc = function() return sv.attributeBarSize end,
             setFunc = function(mode)
                 sv.attributeBarSize = mode
-                SUI.ApplyAttributeBarSize(mode)
+                SUI.AttributeBar:ApplySize(mode)
             end,
             default = SUI.SavedVars.defaults.attributeBarSize,
         },


### PR DESCRIPTION
- Add new "Stacked" layout option for attribute bars with vertical arrangement (health, stamina, magicka)
- Replace pyramid toggle checkbox with comprehensive layout dropdown (Default, ShibUI, Pyramid, Stacked)
- Refactor attribute bar module to use ESO's built-in width constants (SHRUNK_WIDTH, NORMAL_WIDTH, EXPANDED_WIDTH)
- Implement proper colon-style methods (AttributeBar:ApplySize(), AttributeBar:ApplyLayout()) for OOP consistency
- Update SavedVars defaults from `attributeBarPyramid` boolean to `attributeBarLayout` string
- Enhance mount stamina bar positioning in stacked layout alongside regular stamina bar
- Clean up code structure with improved organization and removal of redundant flag variables
- Update version to 1.10.48 and add comprehensive changelog documentation
- Document ZO_PlayerAttribute control structure analysis in CODEBASE.md